### PR TITLE
ADPT-93: Bump camunda version to 7.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,14 @@
                 <version.spring.core>2.0.0.RELEASE</version.spring.core>
                 <version.spring.boot>2.2.7.RELEASE</version.spring.boot>
 
-                <version.camunda>7.10.0</version.camunda>
-                <version.camunda.bpm.spring.boot>3.2.0</version.camunda.bpm.spring.boot>
+                <version.camunda>7.11.0</version.camunda>
+                <version.camunda.bpm.spring.boot>3.3.0</version.camunda.bpm.spring.boot>
+                <version.camunda.bpm.spring.boot.webapps>3.2.0</version.camunda.bpm.spring.boot.webapps>
+                <version.camunda.bpm.spring.boot.test>3.2.0</version.camunda.bpm.spring.boot.test>
                 <version.camunda.bpm.extensions>1.2</version.camunda.bpm.extensions>
-                <version.camunda.spin.engine.plugin>7.10.0</version.camunda.spin.engine.plugin>
-                <version.camunda.spin.dataformat.json.jackson>1.8.0</version.camunda.spin.dataformat.json.jackson>
-                <version.camunda.spin>1.8.0</version.camunda.spin>
+                <version.camunda.spin.engine.plugin>7.11.0</version.camunda.spin.engine.plugin>
+                <version.camunda.spin.dataformat.json.jackson>1.9.0</version.camunda.spin.dataformat.json.jackson>
+                <version.camunda.spin>1.9.0</version.camunda.spin>
                 <version.resteasy.spring.boot>4.5.1.Final</version.resteasy.spring.boot>
                 <version.resteasy.jaxrs>3.0.12.Final</version.resteasy.jaxrs>
                 <version.javax.servlet.api>4.0.1</version.javax.servlet.api>

--- a/taskana-adapter-camunda-spring-boot-test/pom.xml
+++ b/taskana-adapter-camunda-spring-boot-test/pom.xml
@@ -39,6 +39,12 @@
                         <version>${version.camunda.bpm.spring.boot}</version>
                 </dependency>
                 <dependency>
+                        <groupId>org.camunda.bpm.springboot</groupId>
+                        <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+                        <version>${version.camunda.bpm.spring.boot.test}</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
                         <groupId>com.h2database</groupId>
                         <artifactId>h2</artifactId>
                         <version>${version.h2database}</version>
@@ -72,7 +78,7 @@
                 <dependency>
                         <groupId>org.camunda.bpm.springboot</groupId>
                         <artifactId>camunda-bpm-spring-boot-starter-webapp</artifactId>
-                        <version>${version.camunda.bpm.spring.boot}</version>
+                        <version>${version.camunda.bpm.spring.boot.webapps}</version>
                 </dependency>
                 <dependency>
                         <groupId>org.camunda.bpm</groupId>


### PR DESCRIPTION
Please note:

the added camunda-bpm-spring-boot-starter-test dependency is needed, because it has a lot of required transitive test dependencies. It is included in camunda-bpm-spring-boot-starter up until 3.2.0 (camunda 7.10) but not anymore in later version. Therefore it had to be added manually (with scope test) - of course it would be nice if we shifted to JUnit 5 in the future!

Everything is using camunda 7.11 now, which comes with the camunda-bpm-spring-boot-starter 3.3.0 except for the camunda-bpm-spring-boot-starter-webapp, which stays on 3.2.0 version, because it won't work with 3.3.0. This is not an issue, because it is included for "manual debugging" through the UI only. Also, it works again with 7.12 and spring boot starter 3.4.2 (already tested)