### PR TITLE
ADPT-93: Bumped Spring-Boot version to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
                 <version.spring>5.0.5.RELEASE</version.spring>
                 <version.spring.core>2.0.0.RELEASE</version.spring.core>
-                <version.spring.boot>2.2.7.RELEASE</version.spring.boot>
+                <version.spring.boot>2.3.0.RELEASE</version.spring.boot>
 
                 <version.camunda>7.11.0</version.camunda>
                 <version.camunda.bpm.spring.boot>3.3.0</version.camunda.bpm.spring.boot>

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/AbsIntegrationTest.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/AbsIntegrationTest.java
@@ -8,7 +8,6 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -47,8 +46,6 @@ public abstract class AbsIntegrationTest {
   private static boolean isInitialised = false;
 
   @Rule public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
-  @Rule public final ExpectedException exception = ExpectedException.none();
 
   @Value("${taskana.adapter.scheduler.run.interval.for.start.taskana.tasks.in.milliseconds}")
   protected long adapterTaskPollingInterval;

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
@@ -1,12 +1,12 @@
 package pro.taskana.adapter.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -267,7 +267,7 @@ public class TestTaskAcquisition extends AbsIntegrationTest {
       // comparison of the strings doesn't work.
       // rather use SameJSONAs.sameJSONAs from hamcrest-json to compare Json strings independent of
       // child order
-      Assert.assertThat(assumedVariablesString, SameJSONAs.sameJSONAs(taskanaVariablesString));
+      assertThat(assumedVariablesString, SameJSONAs.sameJSONAs(taskanaVariablesString));
 
     } catch (TaskNotFoundException | NotAuthorizedException e) {
       LOGGER.info(


### PR DESCRIPTION
-Removed/changed deprecated methods in AbsIntegrationTest and TestTaskAcquisition