### PR TITLE
ADPT-95: Added git hook, that validates git commits

### DIFF
--- a/qa/hooks/commit-msg
+++ b/qa/hooks/commit-msg
@@ -1,0 +1,15 @@
+#!/bin/bash
+MSG_FILE=$1
+COMMIT_MESSAGE="$(cat $MSG_FILE)"
+REGEX='^((TSK)|(ADPT)-[0-9]+):'
+if [[ $COMMIT_MESSAGE =~ $REGEX ]]; then
+ TICKET=${BASH_REMATCH[1]}
+ RESULT=$(curl -s https://taskana.atlassian.net/rest/api/3/issue/$TICKET)
+ if [[ $RESULT =~ "errorMessages" ]]; then
+  echo -e "\033[0;31mERROR:\033[0m $TICKET is not a valid ticket number"
+  exit 1
+ fi
+else
+ echo -e "\033[0;31mERROR:\033[0m Prefix Git commit messages with the ticket number, e.g. TSK-140: xyz..."
+ exit 1
+fi


### PR DESCRIPTION
Added a small git hook, that validates git commits.
It checks, if commits do follow the structure "TSK-1274: This is an example"
It also validates, that the referenced Task exists on our jira board.
To enable this script please configure your git with: git config core.hooksPath qa/hooks