### PR TITLE
ADPT-161:  Renamed tests according to guidelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <version.wildfly.maven.plugin>3.0.2.Final</version.wildfly.maven.plugin>
     <version.jboss-as-maven-plugin>7.9.Final</version.jboss-as-maven-plugin>
 
+    <version.archunit>0.23.1</version.archunit>
     <version.assertj>3.23.1</version.assertj>
     <version.junit.jupiter>5.9.0</version.junit.jupiter>
     <version.hamcrest.json>0.2</version.hamcrest.json>

--- a/taskana-adapter-camunda-listener/src/test/java/pro/taskana/adapter/camunda/dto/ReferencedTaskTest.java
+++ b/taskana-adapter-camunda-listener/src/test/java/pro/taskana/adapter/camunda/dto/ReferencedTaskTest.java
@@ -36,132 +36,132 @@ public class ReferencedTaskTest {
   }
 
   @Test
-  void should_returnBusinessProcessId_when_BusinessProcessIdWasSet() {
+  void should_ReturnBusinessProcessId_When_BusinessProcessIdWasSet() {
     theTask.setBusinessProcessId(theValue);
     assertThat(theValue).isEqualTo(theTask.getBusinessProcessId());
   }
 
   @Test
-  void should_returnId_when_IdWasSet() {
+  void should_ReturnId_When_IdWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setId(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getId());
   }
 
   @Test
-  void should_returnOutboxEventId_when_OutboxEventIdWasSet() {
+  void should_ReturnOutboxEventId_When_OutboxEventIdWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOutboxEventId(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOutboxEventId());
   }
 
   @Test
-  void should_returnOutboxEventType_when_OutboxEventTypeWasSet() {
+  void should_ReturnOutboxEventType_When_OutboxEventTypeWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOutboxEventType(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOutboxEventType());
   }
 
   @Test
-  void should_returnName_when_NameWasSet() {
+  void should_ReturnName_When_NameWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setName(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getName());
   }
 
   @Test
-  void should_returnAssignee_when_AssigneeWasSet() {
+  void should_ReturnAssignee_When_AssigneeWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setAssignee(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getAssignee());
   }
 
   @Test
-  void should_returnCreated_when_CreatedWasSet() {
+  void should_ReturnCreated_When_CreatedWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setCreated(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getCreated());
   }
 
   @Test
-  void should_returnFollowUp_when_FollowUpWasSet() {
+  void should_ReturnFollowUp_When_FollowUpWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDue(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDue());
   }
 
   @Test
-  void should_returnDue_when_DueWasSet() {
+  void should_ReturnDue_When_DueWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDue(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDue());
   }
 
   @Test
-  void should_returnDescription_when_DescriptionWasSet() {
+  void should_ReturnDescription_When_DescriptionWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDescription(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDescription());
   }
 
   @Test
-  void should_returnOwner_when_OwnerWasSet() {
+  void should_ReturnOwner_When_OwnerWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOwner(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOwner());
   }
 
   @Test
-  void should_returnPriority_when_PriorityWasSet() {
+  void should_ReturnPriority_When_PriorityWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setPriority(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getPriority());
   }
 
   @Test
-  void should_returnSuspended_when_SuspendedWasSet() {
+  void should_ReturnSuspended_When_SuspendedWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setSuspended(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getSuspended());
   }
 
   @Test
-  void should_returnSystemUrl_when_SystemUrlWasSet() {
+  void should_ReturnSystemUrl_When_SystemUrlWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setsystemUrl(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getsystemUrl());
   }
 
   @Test
-  void should_returnTaskDefinitionKey_when_TaskDefinitionKeyWasSet() {
+  void should_ReturnTaskDefinitionKey_When_TaskDefinitionKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setTaskDefinitionKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getTaskDefinitionKey());
   }
 
   @Test
-  void should_returnVariables_when_VariablesWasSet() {
+  void should_ReturnVariables_When_VariablesWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setVariables(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getVariables());
   }
 
   @Test
-  void should_returnDomain_when_DomainWasSet() {
+  void should_ReturnDomain_When_DomainWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDomain(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDomain());
   }
 
   @Test
-  void should_returnClassificationKey_when_ClassificationKeyWasSet() {
+  void should_ReturnClassificationKey_When_ClassificationKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setClassificationKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getClassificationKey());
   }
 
   @Test
-  void should_returnWorkbasketKey_when_WorkbasketKeyWasSet() {
+  void should_ReturnWorkbasketKey_When_WorkbasketKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setWorkbasketKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getWorkbasketKey());
@@ -190,17 +190,17 @@ public class ReferencedTaskTest {
   }
 
   @Test
-  void should_returnHashCode_when_askedToDoSo() {
+  void should_ReturnHashCode_When_AskedToDoSo() {
     assertThat(theTask.hashCode()).isNotNull();
   }
 
   @Test
-  void should_returnString_when_toStringIsCalled() {
+  void should_ReturnString_When_ToStringIsCalled() {
     assertThat(theTask.toString()).isNotNull();
   }
 
   @Test
-  void should_checkEquality_when_equalsIsCalled() {
+  void should_CheckEquality_When_EqualsIsCalled() {
     ReferencedTask refTask2 = theTask;
     refTask2.setWorkbasketKey("nochnkey");
     assertThat(refTask2).isEqualTo(theTask);

--- a/taskana-adapter-camunda-spring-boot-test/pom.xml
+++ b/taskana-adapter-camunda-spring-boot-test/pom.xml
@@ -158,6 +158,12 @@
       <version>${version.junit.jupiter}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <version>${version.archunit}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/ArchitectureTest.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/ArchitectureTest.java
@@ -1,0 +1,41 @@
+package pro.taskana.adapter.integration;
+
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestTemplate;
+
+class ArchitectureTest {
+
+  private static JavaClasses importedClasses;
+
+  @BeforeAll
+  static void init() {
+    // time intensive operation should only be done once
+    importedClasses = new ClassFileImporter().importPackages("pro.taskana", "acceptance");
+  }
+
+  @Test
+  void testMethodNamesShouldMatchAccordingToOurGuidelines() {
+
+    methods()
+        .that(
+            are(
+                annotatedWith(Test.class)
+                    .or(annotatedWith(TestFactory.class))
+                    .or(annotatedWith(TestTemplate.class))))
+        .and()
+        .areNotDeclaredIn(ArchitectureTest.class)
+        .should()
+        .bePackagePrivate()
+        .andShould()
+        .haveNameMatching("^should_[A-Z][^_]+(_(For|When)_[A-Z][^_]+)?$")
+        .check(importedClasses);
+  }
+}

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestCancelledTaskRetrieval.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestCancelledTaskRetrieval.java
@@ -40,7 +40,7 @@ class TestCancelledTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"admin"})
   @Test
-  void deletion_of_taskana_task_should_delete_camunda_task_and_process() throws Exception {
+  void should_DeleteCamundaTaskAndProcess_When_DeleteTaskanaTask() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -88,7 +88,7 @@ class TestCancelledTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void deletion_of_camunda_process_instance_should_terminate_taskana_task() throws Exception {
+  void should_TerminateTaskanaTask_When_DeleteCamundaProcessInstance() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -132,8 +132,7 @@ class TestCancelledTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"admin"})
   @Test
-  void deletion_of_taskana_task_with_deleted_camunda_task_should_be_handled_gracefully()
-      throws Exception {
+  void should_BeAbleToDeleteTaskanaTask_When_DeleteCamundaTask() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -170,7 +169,7 @@ class TestCancelledTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void interruption_of_camunda_task_by_timer_should_cancel_taskana_task() throws Exception {
+  void should_CancelTaskanaTask_When_InterruptionByTimerOfCamundaTaskOccurs() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_timed_user_task_process", "");

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestCompletedTaskRetrieval.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestCompletedTaskRetrieval.java
@@ -47,7 +47,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"admin"})
   @Test
-  void completion_of_taskana_task_should_complete_camunda_task() throws Exception {
+  void should_CompleteCamundaTask_When_CompleteTaskanaTask() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -85,8 +85,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void forced_completion_of_taskana_task_should_set_assignee_and_complete_camunda_task()
-      throws Exception {
+  void should_SetAssigneeAndCompleteCamundaTask_When_ForceCompleteTaskanaTask() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -128,7 +127,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void completion_of_camunda_task_should_complete_taskana_task() throws Exception {
+  void should_CompleteTaskanaTask_When_CompleteCamundaTask() throws Exception {
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", "");
@@ -165,7 +164,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void completion_of_taskana_task_with_new_process_variables_should_set_these_variables_in_camunda()
+  void should_SetVariablesInCamunda_When_CompleteTaskanaTaskWithTheseNewProcessVariables()
       throws Exception {
 
     String processInstanceId =
@@ -273,7 +272,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void completion_of_taskana_task_with_updated_process_variables_should_update_camunda_variables()
+  void should_UpdateCamundaVariables_When_CompleteTaskanaTaskWithTheseUpdatedProcessVariables()
       throws Exception {
 
     String processInstanceId =
@@ -353,7 +352,7 @@ class TestCompletedTaskRetrieval extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void should_preventLoopFromScheduledMethod_When_TryingToCompleteNotAnymoreExistingCamundaTask()
+  void should_PreventLoopFromScheduledMethod_When_TryingToCompleteNoLongerExistingCamundaTask()
       throws Exception {
 
     Logger camundaUtilRequesterLogger =

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
@@ -59,8 +59,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  public void
-      task_with_complex_variables_should_result_in_taskanaTask_with_those_variables_in_custom_attributes()
+  void
+      should_CreateTaskanaTasksWithVariablesInCustomAttributes_When_StartCamundaTaskWithTheseComplexVariables()
           throws Exception {
 
     String processInstanceId =
@@ -112,8 +112,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void user_task_process_instance_started_in_camunda_via_rest_should_result_in_taskanaTask()
-      throws Exception {
+  void should_CreateTaskanaTask_When_StartUserTaskProcessInstanceInCamunda() throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -140,7 +139,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       groups = {"taskadmin"})
   @Test
   void
-      user_task_process_instance_with_empty_extension_property_started_in_camunda_via_rest_should_result_in_taskanaTask()
+      should_CreateTaskanaTask_When_StartUserTaskProcessInstanceWithEmptyExtensionPropertyInCamunda()
           throws Exception {
 
     String processInstanceId =
@@ -203,9 +202,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      multiple_user_task_process_instances_started_in_camunda_via_rest_should_result_in_multiple_taskanaTasks()
-          throws Exception {
+  void should_CreateMultipleTaskanaTasks_When_StartMultipleUserTaskProcessInstanceInCamunda()
+      throws Exception {
 
     int numberOfProcesses = 10;
     List<List<String>> camundaTaskIdsList = new ArrayList<>();
@@ -233,9 +231,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      task_with_primitive_variables_should_result_in_taskanaTask_with_those_variables_in_custom_attributes()
-          throws Exception {
+  void should_CreateTaskanaTask_When_StartCamundaTaskWithPrimitiveVariables() throws Exception {
 
     String variables =
         "\"variables\": {\"amount\": {\"value\":555, "
@@ -270,7 +266,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void task_with_manual_priority_should_result_in_taskanaTask_with_this_manual_priority()
+  void should_CreateTaskanaTaskWithManualPriority_When_StartCamundaTaskWithThisManualPriority()
       throws Exception {
 
     String variables =
@@ -294,8 +290,9 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void task_without_manual_priority_should_result_in_taskanaTask_with_default_manual_priority()
-      throws Exception {
+  void
+      should_CreateTaskanaTaskWithDefaultManualPriority_When_StartCamundaTaskWithoutManualPriority()
+          throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -381,7 +378,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       groups = {"taskadmin"})
   @Test
   void
-      task_with_big_complex_variables_should_result_in_taskanaTask_with_those_variables_in_custom_attributes()
+      should_CreateTaskanaTaskWithComplexVariablesInCustomAttributes_When_StartCamundaTaskWithTheseVariables()
           throws Exception {
 
     String processInstanceId =
@@ -413,7 +410,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       groups = {"taskadmin"})
   @Test
   void
-      task_with_complex_variables_from_parent_execution_should_result_in_taskanaTasks_with_those_variables_in_custom_attributes()
+      should_CreateTaskanaTasksWithComplexVariablesInCustomAttributes_When_ParentExecutionOfCamundaTasksStarted()
           throws Exception {
 
     String processInstanceId =
@@ -479,7 +476,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void process_instance_with_multiple_executions_should_result_in_multiple_taskanaTasks()
+  void should_CreateMultipleTaskanaTasks_When_StartProcessInstanceWithMultipleExecutionsInCamunda()
       throws Exception {
 
     String processInstanceId =
@@ -504,7 +501,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void should_createTaskanaTask_When_SystemConnectorHasCorrectSystemEngineIdentifier()
+  void should_CreateTaskanaTask_When_SystemConnectorHasCorrectSystemEngineIdentifier()
       throws Exception {
 
     final Map<String, SystemConnector> originalSystemConnectors =
@@ -539,8 +536,9 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void process_with_different_domains_in_tasks_should_result_in_taskanaTasks_with_those_domains()
-      throws Exception {
+  void
+      should_CreateTaskanaTasksWithDifferentDomains_When_StartProcessWithDifferentDomainsInCamunda()
+          throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -584,7 +582,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void should_notCreateTaskanaTask_When_SystemConnectorHasIncorrectSystemEngineIdentifier()
+  void should_NotCreateTaskanaTask_When_SystemConnectorHasIncorrectSystemEngineIdentifier()
       throws Exception {
 
     final Map<String, SystemConnector> originalSystemConnectors =
@@ -621,7 +619,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       groups = {"taskadmin"})
   @Test
   void
-      process_with_different_variables_in_tasks_should_result_in_taskanaTasks_with_those_variables_in_custom_attributes()
+      should_CreateTaskanaTasksWithVariablesInCustomAttributes_When_StartProcessWithTheseDifferentVariablesInCamunda()
           throws Exception {
 
     String processInstanceId =
@@ -672,7 +670,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"admin"})
   @Test
-  void should_SetPlannedDateInTaskanaTask_When_CamundaTaskHasFollowUpDate() throws Exception {
+  void should_SetPlannedDateInTaskanaTask_When_StartCamundaTaskWithFollowUpDate() throws Exception {
     final Instant now = Instant.now();
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskClaim.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskClaim.java
@@ -40,7 +40,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void claim_of_taskana_task_should_claim_unclaimed_camunda_task() throws Exception {
+  void should_ClaimUnclaimedCamundaTask_When_ClaimTaskanaTask() throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -87,7 +87,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void claim_of_taskana_task_should_claim_already_claimed_camunda_task() throws Exception {
+  void should_ClaimAlreadyClaimedCamundaTaska_When_ClaimTaskanaTask() throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -134,7 +134,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void cancel_claim_of_taskana_task_should_cancel_claim_of_camunda_task() throws Exception {
+  void should_CancelClaimCamundaTask_When_CancelClaimTaskanaTask() throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -188,8 +188,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void claim_of_taskana_task_after_cancel_claim_should_claim_task_in_camunda_again()
-      throws Exception {
+  void should_ClaimCamundaTaskAgain_When_ClaimTaskanaTaskAfterCancelClaim() throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -255,7 +254,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void should_preventLoopFromScheduledMethod_When_TryingToClaimNotAnymoreExistingCamundaTask()
+  void should_ReventLoopFromScheduledMethod_When_TryingToClaimNotAnymoreExistingCamundaTask()
       throws Exception {
 
     Logger camundaUtilRequesterLogger =
@@ -314,7 +313,7 @@ class TestTaskClaim extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void should_preventLoopFromScheduledMethod_When_TryingToCancelClaimNotAnymoreExistingCamundaTask()
+  void should_PreventLoopFromScheduledMethod_When_TryingToCancelClaimNotAnymoreExistingCamundaTask()
       throws Exception {
 
     Logger camundaUtilRequesterLogger =

--- a/taskana-adapter-camunda-system-connector/src/test/java/pro/taskana/camunda/camundasystemconnector/acceptance/RetrieveCamundaTaskAccTest.java
+++ b/taskana-adapter-camunda-system-connector/src/test/java/pro/taskana/camunda/camundasystemconnector/acceptance/RetrieveCamundaTaskAccTest.java
@@ -49,7 +49,7 @@ public class RetrieveCamundaTaskAccTest {
   }
 
   @Test
-  public void testGetActiveCamundaTasks() {
+  public void should_GetActiveCamundaTask() {
 
     String timeStamp = "2019-01-14T15:22:30.811+0000";
 
@@ -132,7 +132,7 @@ public class RetrieveCamundaTaskAccTest {
   }
 
   @Test
-  public void testGetFinishedCamundaTasks() {
+  public void should_GetFinishedCamundaTask() {
 
     ReferencedTask expectedTask = new ReferencedTask();
     expectedTask.setId("2275fb87-1065-11ea-a7a0-02004c4f4f50");

--- a/taskana-adapter/src/test/java/pro/taskana/adapter/systemconnector/api/ReferencedTaskTest.java
+++ b/taskana-adapter/src/test/java/pro/taskana/adapter/systemconnector/api/ReferencedTaskTest.java
@@ -38,125 +38,125 @@ public class ReferencedTaskTest {
   }
 
   @Test
-  void should_returnBusinessProcessId_when_BusinessProcessIdWasSet() {
+  void should_ReturnBusinessProcessId_When_BusinessProcessIdWasSet() {
     theTask.setBusinessProcessId(theValue);
     assertThat(theValue).isEqualTo(theTask.getBusinessProcessId());
   }
 
   @Test
-  void should_returnId_when_IdWasSet() {
+  void should_ReturnId_When_IdWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setId(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getId());
   }
 
   @Test
-  void should_returnOutboxEventId_when_OutboxEventIdWasSet() {
+  void should_ReturnOutboxEventId_When_OutboxEventIdWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOutboxEventId(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOutboxEventId());
   }
 
   @Test
-  void should_returnOutboxEventType_when_OutboxEventTypeWasSet() {
+  void should_ReturnOutboxEventType_When_OutboxEventTypeWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOutboxEventType(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOutboxEventType());
   }
 
   @Test
-  void should_returnName_when_NameWasSet() {
+  void should_ReturnName_When_NameWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setName(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getName());
   }
 
   @Test
-  void should_returnAssignee_when_AssigneeWasSet() {
+  void should_ReturnAssignee_When_AssigneeWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setAssignee(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getAssignee());
   }
 
   @Test
-  void should_returnCreated_when_CreatedWasSet() {
+  void should_ReturnCreated_When_CreatedWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setCreated(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getCreated());
   }
 
   @Test
-  void should_returnDue_when_DueWasSet() {
+  void should_ReturnDue_When_DueWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDue(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDue());
   }
 
   @Test
-  void should_returnDescription_when_DescriptionWasSet() {
+  void should_ReturnDescription_When_DescriptionWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDescription(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDescription());
   }
 
   @Test
-  void should_returnOwner_when_OwnerWasSet() {
+  void should_ReturnOwner_When_OwnerWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setOwner(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getOwner());
   }
 
   @Test
-  void should_returnPriority_when_PriorityWasSet() {
+  void should_ReturnPriority_When_PriorityWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setPriority(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getPriority());
   }
 
   @Test
-  void should_returnSuspended_when_SuspendedWasSet() {
+  void should_ReturnSuspended_When_SuspendedWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setSuspended(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getSuspended());
   }
 
   @Test
-  void should_returnSystemUrl_when_SystemUrlWasSet() {
+  void should_ReturnSystemUrl_When_SystemUrlWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setSystemUrl(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getSystemUrl());
   }
 
   @Test
-  void should_returnTaskDefinitionKey_when_TaskDefinitionKeyWasSet() {
+  void should_ReturnTaskDefinitionKey_When_TaskDefinitionKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setTaskDefinitionKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getTaskDefinitionKey());
   }
 
   @Test
-  void should_returnVariables_when_VariablesWasSet() {
+  void should_ReturnVariables_When_VariablesWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setVariables(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getVariables());
   }
 
   @Test
-  void should_returnDomain_when_DomainWasSet() {
+  void should_ReturnDomain_When_DomainWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setDomain(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getDomain());
   }
 
   @Test
-  void should_returnClassificationKey_when_ClassificationKeyWasSet() {
+  void should_ReturnClassificationKey_When_ClassificationKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setClassificationKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getClassificationKey());
   }
 
   @Test
-  void should_returnWorkbasketKey_when_WorkbasketKeyWasSet() {
+  void should_ReturnWorkbasketKey_When_WorkbasketKeyWasSet() {
     ReferencedTask referencedTask = new ReferencedTask();
     referencedTask.setWorkbasketKey(theValue);
     assertThat(theValue).isEqualTo(referencedTask.getWorkbasketKey());
@@ -189,17 +189,17 @@ public class ReferencedTaskTest {
   }
 
   @Test
-  void should_returnHashCode_when_askedToDoSo() {
+  void should_ReturnHashCode_When_AskedToDoSo() {
     assertThat(theTask.hashCode()).isNotNull();
   }
 
   @Test
-  void should_returnString_when_toStringIsCalled() {
+  void should_ReturnString_When_ToStringIsCalled() {
     assertThat(theTask.toString()).isNotNull();
   }
 
   @Test
-  void should_checkEquality_when_equalsIsCalled() {
+  void should_CheckEquality_When_EqualsIsCalled() {
     ReferencedTask refTask2 = theTask;
     refTask2.setWorkbasketKey("nochnkey");
     assertThat(refTask2).isEqualTo(theTask);


### PR DESCRIPTION
Renamed tests according to coding guidelines. Introduce Architecture Test checking name conventions in tests.

[Sonar](https://sonarcloud.io/summary/new_code?id=ensarevlideveloper_TaskanaAdapter&branch=ADPT-161)
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [X] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I put the ticket in review

### Verified by the reviewer:
- [ ] Commit message format → ADPT-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability

