### PR TITLE
ADPT-168: Domain can be defined by process variable

### DIFF
--- a/taskana-adapter-camunda-listener/src/main/java/pro/taskana/adapter/camunda/tasklistener/TaskanaTaskListener.java
+++ b/taskana-adapter-camunda-listener/src/main/java/pro/taskana/adapter/camunda/tasklistener/TaskanaTaskListener.java
@@ -240,7 +240,11 @@ public class TaskanaTaskListener implements TaskListener {
   }
 
   private String getDomainVariable(DelegateTask delegateTask) {
-    String taskDomain = getUserTaskExtensionProperty(delegateTask, "taskana.domain");
+    String taskDomain = getVariable(delegateTask, "taskana.domain", null);
+    if (taskDomain != null) {
+      return taskDomain;
+    }
+    taskDomain = getUserTaskExtensionProperty(delegateTask, "taskana.domain");
     if (taskDomain != null) {
       return taskDomain;
     }

--- a/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
+++ b/taskana-adapter-camunda-spring-boot-test/src/test/java/pro/taskana/adapter/integration/TestTaskAcquisition.java
@@ -536,8 +536,54 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
+  void should_CreateTaskanaTasksWithCorrectDomains_When_StartProcessWithDomainsInProcessVariables()
+      throws Exception {
+    String processInstanceId =
+        this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
+            "simple_user_task_process_with_different_domains",
+            "\"variables\": "
+                + "{\"taskana.domain\": {\"value\":\"DOMAIN_B\", \"type\":\"string\"}}");
+    List<String> camundaTaskIds =
+        this.camundaProcessengineRequester.getTaskIdsFromProcessInstanceId(processInstanceId);
+    assertThat(camundaTaskIds).hasSize(3);
+    Thread.sleep((long) (this.adapterTaskPollingInterval * 1.2));
+
+    List<Pair<String, String>> variablesToTaskList =
+        Arrays.asList(
+            Pair.of("DOMAIN_B", camundaTaskIds.get(0)),
+            Pair.of("DOMAIN_B", camundaTaskIds.get(1)),
+            Pair.of("DOMAIN_B", camundaTaskIds.get(2)));
+
+    for (Pair<String, String> variablesToTask : variablesToTaskList) {
+      List<TaskSummary> taskanaTaskSummaryList =
+          this.taskService.createTaskQuery().externalIdIn(variablesToTask.getRight()).list();
+      assertThat(taskanaTaskSummaryList).hasSize(1);
+      TaskSummary taskanaTaskSummary = taskanaTaskSummaryList.get(0);
+
+      Task taskanaTask = taskService.getTask(taskanaTaskSummary.getId());
+      assertThat(taskanaTask.getDomain()).isEqualTo(variablesToTask.getLeft());
+    }
+
+    this.camundaProcessengineRequester.completeTaskWithId(camundaTaskIds.get(2));
+    camundaTaskIds =
+        this.camundaProcessengineRequester.getTaskIdsFromProcessInstanceId(processInstanceId);
+    assertThat(camundaTaskIds).hasSize(3);
+    Thread.sleep((long) (this.adapterTaskPollingInterval * 1.2));
+
+    List<TaskSummary> taskanaTaskSummaryList =
+        this.taskService.createTaskQuery().externalIdIn(camundaTaskIds.get(2)).list();
+    assertThat(taskanaTaskSummaryList).hasSize(1);
+    TaskSummary taskanaTaskSummary = taskanaTaskSummaryList.get(0);
+    Task taskanaTask = taskService.getTask(taskanaTaskSummary.getId());
+    assertThat(taskanaTask.getDomain()).isEqualTo("DOMAIN_B");
+  }
+
+  @WithAccessId(
+      user = "teamlead_1",
+      groups = {"taskadmin"})
+  @Test
   void
-      should_CreateTaskanaTasksWithDifferentDomains_When_StartProcessWithDifferentDomainsInCamunda()
+      should_CreateTaskanaTasksWithCorrectDomains_When_StartProcessWithDomainsInExtensionProperties()
           throws Exception {
 
     String processInstanceId =


### PR DESCRIPTION
Domain can now be specified through process variables.
* Updated documentation ([Adapter documentation](https://taskana.atlassian.net/wiki/spaces/TAS/pages/881164289/Camunda+BPM+Connector))
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [X] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [X] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I put the ticket in review

### Verified by the reviewer:
- [ ] Commit message format → ADPT-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability

