### PR TITLE
ADPT-160: H2 Update to v2.1.214

### DIFF
--- a/camunda-outbox-example-boot/pom.xml
+++ b/camunda-outbox-example-boot/pom.xml
@@ -23,7 +23,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/camunda-outbox-example-boot/src/main/resources/application.properties
+++ b/camunda-outbox-example-boot/src/main/resources/application.properties
@@ -15,7 +15,7 @@ camunda.bpm.database.type=h2
 #spring.datasource.username = postgres
 #spring.datasource.password = postgres
 
-spring.datasource.url=jdbc:h2:mem:camunda;IGNORECASE=TRUE;DB_CLOSE_ON_EXIT=FALSE;
+spring.datasource.url=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;DB_CLOSE_ON_EXIT=FALSE;
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=sa

--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,12 @@
 
     <version.mybatis>3.5.11</version.mybatis>
     <version.spring.mybatis>2.2.2</version.spring.mybatis>
-    <version.h2database>1.4.200</version.h2database>
 
     <version.spring>5.0.5.RELEASE</version.spring>
     <version.spring.core>3.0.0</version.spring.core>
     <version.spring.boot>2.7.5</version.spring.boot>
 
-    <version.camunda>7.16.0</version.camunda>
+    <version.camunda>7.17.0</version.camunda>
     <version.camunda.bpm.extensions>1.2</version.camunda.bpm.extensions>
     <version.camunda.spin>1.18.0</version.camunda.spin>
     <version.resteasy.spring.boot>5.0.0.Final</version.resteasy.spring.boot>

--- a/taskana-adapter-camunda-listener-example/pom.xml
+++ b/taskana-adapter-camunda-listener-example/pom.xml
@@ -100,7 +100,6 @@
       <!-- Needed for InMemoryH2Test -->
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/taskana-adapter-camunda-outbox-rest/src/main/resources/taskana-outbox.properties
+++ b/taskana-adapter-camunda-outbox-rest/src/main/resources/taskana-outbox.properties
@@ -12,7 +12,7 @@ taskana.adapter.outbox.duration.between.task.creation.retries = PT1H
 #taskana.adapter.outbox.datasource.username=postgres
 #taskana.adapter.outbox.datasource.password=postgres
 
-taskana.adapter.outbox.datasource.url=jdbc:h2:mem:camunda;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;
+taskana.adapter.outbox.datasource.url=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;
 taskana.adapter.outbox.datasource.driver=org.h2.Driver
 taskana.adapter.outbox.datasource.username=sa
 taskana.adapter.outbox.datasource.password=sa

--- a/taskana-adapter-camunda-spring-boot-example/pom.xml
+++ b/taskana-adapter-camunda-spring-boot-example/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/taskana-adapter-camunda-spring-boot-example/src/main/resources/application.properties
+++ b/taskana-adapter-camunda-spring-boot-example/src/main/resources/application.properties
@@ -39,7 +39,7 @@ taskana-system-connector-camundaSystemURLs=http://localhost:8081/example-context
 ####################################################################################
 #
 # Configure the datasource for Taskana DB (used by taskana-connector)
-taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:9095/mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;
+taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:9095/mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;
 taskana.datasource.driverClassName = org.h2.Driver
 taskana.datasource.username = sa
 taskana.datasource.password = sa

--- a/taskana-adapter-camunda-spring-boot-test/pom.xml
+++ b/taskana-adapter-camunda-spring-boot-test/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
       <scope>test</scope>
     </dependency>
     <!--

--- a/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties
+++ b/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties
@@ -45,8 +45,8 @@ taskana-system-connector-outbox-rest-api-user-password=pwd4OutboxRestUser
 ####################################################################################
 #
 # Datasource for Taskana DB (used by taskana-connector and taskana lib)
-# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
-taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
+# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
+taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
 taskana.datasource.driverClassName = org.h2.Driver
 taskana.datasource.username = sa
 taskana.datasource.password = sa
@@ -73,9 +73,9 @@ taskana.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
 ## Camunda properties
 
 #H2
-#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
-#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
- camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
+#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
+#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+ camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
  camunda.datasource.driverClassName=org.h2.Driver
  camunda.datasource.username=sa
  camunda.datasource.password=sa

--- a/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties.h2
+++ b/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties.h2
@@ -38,8 +38,8 @@ taskana-system-connector-camundaSystemURLs=http://localhost:${server.port}/engin
 ####################################################################################
 #
 # Datasource for Taskana DB (used by taskana-connector and taskana lib)
-# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
-taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
+# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
+taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
 taskana.datasource.driverClassName = org.h2.Driver
 taskana.datasource.username = sa
 taskana.datasource.password = sa
@@ -66,9 +66,9 @@ taskana.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
 ## Camunda properties
 
 #H2
-#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
-#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
+#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
+#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
 camunda.datasource.driverClassName=org.h2.Driver
 camunda.datasource.username=sa
 camunda.datasource.password=sa

--- a/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties.postgres
+++ b/taskana-adapter-camunda-spring-boot-test/src/main/resources/application.properties.postgres
@@ -38,8 +38,8 @@ taskana-system-connector-camundaSystemURLs=http://localhost:${server.port}/engin
 ####################################################################################
 #
 # Datasource for Taskana DB (used by taskana-connector and taskana lib)
-# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
-##taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
+# taskana.datasource.jdbcUrl = jdbc:h2:tcp://localhost:8092/mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS TASKANA
+##taskana.datasource.jdbcUrl=jdbc:h2:mem:taskana;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
 ##taskana.datasource.driverClassName = org.h2.Driver
 ##taskana.datasource.username = sa
 ##taskana.datasource.password = sa
@@ -66,9 +66,9 @@ taskana.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
 ## Camunda properties
 
 #H2
-#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
-#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-## camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
+#camunda.datasource.jdbcUrl= jdbc:h2:./camunda-db;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE
+#camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+## camunda.datasource.jdbcUrl=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
 ## camunda.datasource.driverClassName=org.h2.Driver
 ## camunda.datasource.username=sa
 ## camunda.datasource.password=sa

--- a/taskana-adapter-camunda-spring-boot-test/src/main/resources/taskana-outbox.properties
+++ b/taskana-adapter-camunda-spring-boot-test/src/main/resources/taskana-outbox.properties
@@ -11,7 +11,7 @@ taskana.adapter.outbox.duration.between.task.creation.retries = PT1S
 #taskana.adapter.outbox.datasource.password=postgres
 
 taskana.adapter.outbox.datasource.driver = org.h2.Driver
-taskana.adapter.outbox.datasource.url=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+taskana.adapter.outbox.datasource.url=jdbc:h2:mem:camunda;NON_KEYWORDS=KEY,VALUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 taskana.adapter.outbox.datasource.username=sa
 taskana.adapter.outbox.datasource.password=sa
 

--- a/taskana-adapter-camunda-wildfly-example/pom.xml
+++ b/taskana-adapter-camunda-wildfly-example/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.plugin</groupId>
@@ -132,7 +131,8 @@
       -->
       <properties>
         <driver-class>org.h2.Driver</driver-class>
-        <connection-url>datasource.url=jdbc:h2:mem:tca;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE
+        <connection-url>
+          datasource.url=jdbc:h2:mem:tca;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE
           SCHEMA IF NOT EXISTS TCA
         </connection-url>
         <driver-name>h2driver</driver-name>

--- a/taskana-adapter-taskana-connector/pom.xml
+++ b/taskana-adapter-taskana-connector/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2database}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
To update H2 to 2.x we need to introduce the SET NON_KEYWORDS command. POM is adapted such that h2 is on version 2.1.214. Please not that the taskana version has to be adapted to the new taskana release.

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review

### Verified by the reviewer:
- [ ] Commit message format → ADPT-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability

